### PR TITLE
Parameters at location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,9 @@ target/
 # Jupyter Notebook
 .ipynb_checkpoints
 
+# PyCharm
+.idea
+
 # pyenv
 .python-version
 

--- a/hkvfewspy/io/rest_fewspi.py
+++ b/hkvfewspy/io/rest_fewspi.py
@@ -531,7 +531,7 @@ class PiRest(object):
 
         url = "{}timeseries".format(self.url)
         # check if input is a queryParameters is class and not dictionary
-        if not isinstance(queryParameters, collections.Mapping):
+        if not isinstance(queryParameters, collections.abc.Mapping):
             # if so try extract the query
             queryParameters = queryParameters.query
 

--- a/hkvfewspy/io/rest_fewspi.py
+++ b/hkvfewspy/io/rest_fewspi.py
@@ -375,7 +375,7 @@ class PiRest(object):
                     "lon": location["lon"],
                     "x": location["x"],
                     "y": location["y"],
-                    "parametersNames": param_list
+                    "parameterNames": param_list
                 },
             )
 

--- a/hkvfewspy/io/rest_fewspi.py
+++ b/hkvfewspy/io/rest_fewspi.py
@@ -358,7 +358,10 @@ class PiRest(object):
         locations = json_data.get("locations")
 
         for location in json_data.get("locations"):
-            locId = location["locationId"].replace(".", "_")
+            if location["locationId"][:1].isdigit():
+                locId = "L{0}".format(location["locationId"]).replace(".", "_")
+            else:
+                locId = location["locationId"].replace(".", "_")
 
             # set attributes of object with location items
             param_list = [elem["value"] for elem in location["attributes"] if elem["name"]=="WNS"]

--- a/hkvfewspy/io/rest_fewspi.py
+++ b/hkvfewspy/io/rest_fewspi.py
@@ -364,6 +364,7 @@ class PiRest(object):
                 locId = location["locationId"].replace(".", "_")
 
             # set attributes of object with location items
+            param_list = [elem["value"] for elem in location["attributes"] if elem["name"]=="WNS"]
             setattr(
                 self.Locations.dict,
                 locId,
@@ -374,6 +375,7 @@ class PiRest(object):
                     "lon": location["lon"],
                     "x": location["x"],
                     "y": location["y"],
+                    "parametersNames": param_list
                 },
             )
 

--- a/hkvfewspy/io/rest_fewspi.py
+++ b/hkvfewspy/io/rest_fewspi.py
@@ -358,10 +358,7 @@ class PiRest(object):
         locations = json_data.get("locations")
 
         for location in json_data.get("locations"):
-            if location["locationId"][:1].isdigit():
-                locId = "L{0}".format(location["locationId"]).replace(".", "_")
-            else:
-                locId = location["locationId"].replace(".", "_")
+            locId = location["locationId"].replace(".", "_")
 
             # set attributes of object with location items
             param_list = [elem["value"] for elem in location["attributes"] if elem["name"]=="WNS"]

--- a/hkvfewspy/io/rest_fewspi.py
+++ b/hkvfewspy/io/rest_fewspi.py
@@ -119,6 +119,23 @@ class PiRest(object):
         setattr(self, "TimeZoneId", response.text)
         return response.text
 
+    def getFlags(self):
+        """
+        get the explanation of the numbers for the flags
+
+        all the results of get*** functions are also written back in the class object without 'get'
+        (eg result of Pi.getFlags() is stored in Pi.Flags)
+        """
+
+        url = "{}flags".format(self.url)
+
+        response = requests.get(url,verify=self.verify)
+
+        json_data = json.loads(response.text)
+        df = pd.json_normalize(json_data['flags']).set_index('flag')
+        setattr(self, "Flags", df)
+
+
     def _addFilter(self, filter):
         """
         Add a filter to the collection


### PR DESCRIPTION
extending the dataframe of PiREST.getLocations, so it is clear which parameters are present at a location. This information is given by the FEWS REST service, but is not put in the resulting dataframe. With this pull request, this is now fixed. A collumn "parametersNames" is added giving a list of strings